### PR TITLE
Update README.md - Change URLs from http to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 SublimeLinter-contrib-yaml-lint
 ================================
 
-This linter plugin for [SublimeLinter](http://sublimelinter.readthedocs.org/) provides an interface to the [yaml-lint](https://github.com/Pryz/yaml-lint) gem. It will be used with files that have the “YAML” syntax.
+This linter plugin for [SublimeLinter](https://sublimelinter.readthedocs.org/) provides an interface to the [yaml-lint](https://github.com/Pryz/yaml-lint) gem. It will be used with files that have the â€œYAMLâ€ syntax.
 
 ## Installation
-SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 3 is not installed, please follow the instructions [here](http://sublimelinter.readthedocs.org/en/latest/installation.html).
+SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 3 is not installed, please follow the instructions [here](https://sublimelinter.readthedocs.org/en/latest/installation.html).
 
 ### Linter installation
 Before using this plugin, you must ensure that `yaml-lint >= 0.0.9` is installed on your system. To install `yaml-lint`, do the following:
 
-1. Install [Ruby](http://ruby-lang.org).
+1. Install [Ruby](https://ruby-lang.org).
 
 1. Install `yaml-lint` by typing the following in a terminal:
    ```
@@ -21,16 +21,16 @@ In order for `yaml-lint` to be executed by SublimeLinter, you must ensure that i
 Once you have installed `yaml-lint`, you can proceed to install the SublimeLinter-contrib-yaml-lint plugin if it is not yet installed.
 
 ### Plugin installation
-Please use [Package Control](https://sublime.wbond.net/installation) to install the linter plugin. This will ensure that the plugin will be updated when new versions are available. If you want to install from source so you can modify the source code, you probably know what you are doing so we won’t cover that here.
+Please use [Package Control](https://sublime.wbond.net/installation) to install the linter plugin. This will ensure that the plugin will be updated when new versions are available. If you want to install from source so you can modify the source code, you probably know what you are doing so we wonâ€™t cover that here.
 
 To install via Package Control, do the following:
 
-1. Within Sublime Text, bring up the [Command Palette](http://docs.sublimetext.info/en/sublime-text-3/extensibility/command_palette.html) and type `install`. Among the commands you should see `Package Control: Install Package`. If that command is not highlighted, use the keyboard or mouse to select it. There will be a pause of a few seconds while Package Control fetches the list of available plugins.
+1. Within Sublime Text, bring up the [Command Palette](https://docs.sublimetext.info/en/sublime-text-3/extensibility/command_palette.html) and type `install`. Among the commands you should see `Package Control: Install Package`. If that command is not highlighted, use the keyboard or mouse to select it. There will be a pause of a few seconds while Package Control fetches the list of available plugins.
 
 1. When the plugin list appears, type `yaml-lint`. Among the entries you should see `SublimeLinter-contrib-yaml-lint`. If that entry is not highlighted, use the keyboard or mouse to select it.
 
 ## Settings
-For general information on how SublimeLinter works with settings, please see [Settings](http://sublimelinter.readthedocs.org/en/latest/settings.html). For information on generic linter settings, please see [Linter Settings](http://sublimelinter.readthedocs.org/en/latest/linter_settings.html).
+For general information on how SublimeLinter works with settings, please see [Settings](https://sublimelinter.readthedocs.org/en/latest/settings.html). For information on generic linter settings, please see [Linter Settings](https://sublimelinter.readthedocs.org/en/latest/linter_settings.html).
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
@@ -45,7 +45,7 @@ Please note that modications should follow these coding guidelines:
 
 - Indent is tab.
 - Code should pass flake8 and pep257 linters.
-- Vertical whitespace helps readability, don’t be afraid to use it.
+- Vertical whitespace helps readability, donâ€™t be afraid to use it.
 - Please use descriptive variable names, no abbrevations unless they are very well known.
 
 Thank you for helping out!


### PR DESCRIPTION
On my browser.OS combination (see table below), when I clicked a link with my middle mouse button, a new tab would open, but I'd receive a `Server Not Found Error`, even though the URL is valid. Once I changed the transport designation from HTTP to HTTPS, the links would open just fine. I even had [HTTPS Everywhere](https://www.eff.org/https-everywhere) installed as a browser plug-in, so I'm kind of stumped as to why it didn't automatically rewrite the URLs.

| Param | Value |
| :--- | :--- |
| Browser and Edition |  Firefox 96.0.2 (64-bit) |
| OS Edition | Windows 11 Home |
| OS Version | 21H2 |
| OS build | 22000.434 |
| OS Experience | Windows Feature Experience Pack 1000.22000.434.0 |