### PR TITLE
Update URL: ruby-lang.org --> www.ruby-lang.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 
 ### Linter installation
 Before using this plugin, you must ensure that `yaml-lint >= 0.0.9` is installed on your system. To install `yaml-lint`, do the following:
 
-1. Install [Ruby](https://ruby-lang.org).
+1. Install [Ruby](https://www.ruby-lang.org).
 
 1. Install `yaml-lint` by typing the following in a terminal:
    ```


### PR DESCRIPTION
My explanation for the cause of the issue mentioned in my previous request, specifically, receiving a `Server not found` error when attempting to open the link using middle-mouse button, was incorrect. I thought it was because the links needed to be specified as HTTPS instead of HTTP. The correct explanation is that the domain, *ruby-lang.org* must be specified as [www.ruby-lang.org](https://www.ruby-lang.org) when opening the link in a browser via CTRL+CLICK or the middle mouse button.